### PR TITLE
fix issues with verbs having a terminal 'e', and also 'fixxed' as a consequence

### DIFF
--- a/lib/suffix.ex
+++ b/lib/suffix.ex
@@ -1,13 +1,13 @@
 defmodule Suffix do
 
-  @consonant_pattern "[bcdfghjklmnpqrstvwxz]"
+  @consonant_pattern "[bcdfghjklmnpqrstvz]"
   @doubled_consonant_pattern "[bcdfghklmnprstz]{2}"
   @vowel_pattern "[aeiouy]"
   @doubled_vowel_pattern "[aeiouy]"
 
   def with_ed(infinitive) do
     cond do
-      ends_consonant_plus_e?(infinitive) -> infinitive <> "d"
+      ends_e?(infinitive) -> infinitive <> "d"
       ends_consonant_plus_y?(infinitive) ->
         String.replace_suffix(infinitive, "y", "ied")
       ends_vowel_lf?(infinitive) ->
@@ -34,7 +34,7 @@ defmodule Suffix do
   def with_s(infinitive) do
     cond do
       Regex.match?(~r/ch$/i, infinitive) -> infinitive <> "es"
-      ends_consonant_plus_e?(infinitive) -> infinitive <> "s"
+      ends_e?(infinitive) -> infinitive <> "s"
       ends_consonant_plus_y?(infinitive) -> String.replace_suffix(infinitive, "y", "ies")
       ends_vowel_lf?(infinitive) -> String.replace_suffix(infinitive, "lf", "lves")
       ends_aiou?(infinitive) -> infinitive <> "es"
@@ -54,8 +54,10 @@ defmodule Suffix do
     Regex.match?(regex, infinitive)
   end
 
+  #  Except for words like refer and prefer, in which case the
+  #  r is doubled.
   def ends_er?(infinitive) do
-    Regex.match?(~r/er/, infinitive)
+    Regex.match?(~r/[^f]er/, infinitive)
   end
 
   def ends_consonant_plus_y?(infinitive) do
@@ -63,8 +65,9 @@ defmodule Suffix do
     Regex.match?(regex, infinitive)
   end
 
-  def ends_consonant_plus_e?(infinitive) do
-    {:ok, regex} = Regex.compile(@consonant_pattern <> "e$","i")
+  def ends_e?(infinitive) do
+#    {:ok, regex} = Regex.compile(@consonant_pattern <> "e$","i")
+    {:ok, regex} = Regex.compile("e$","i")
     Regex.match?(regex, infinitive)
   end
 

--- a/test/conjugate_regular_test.exs
+++ b/test/conjugate_regular_test.exs
@@ -155,6 +155,7 @@ defmodule ConjugateRegularTest do
       %{tense: "past", verb: "miter", expected: "mitered"},
       %{tense: "past", verb: "corner", expected: "cornered"},
       %{tense: "past", verb: "belittle", expected: "belittled"},
+      %{tense: "past", verb: "rescue", expected: "rescued"},
     ]
     |> Enum.each( fn tc ->
       options = %{:tense => tc.tense, :person => "first", :plurality => "singular"}

--- a/test/suffix_test.exs
+++ b/test/suffix_test.exs
@@ -18,12 +18,12 @@ defmodule SuffixTest do
     assert Suffix.ends_consonant_plus_y?("run") == false
   end
 
-  test "ends_consonant_plus_e?" do
-    assert Suffix.ends_consonant_plus_e?("vote") == true
-    assert Suffix.ends_consonant_plus_e?("stitch") == false
-    assert Suffix.ends_consonant_plus_e?("inn") == false
-    assert Suffix.ends_consonant_plus_e?("carry") == false
-    assert Suffix.ends_consonant_plus_e?("run") == false
+  test "ends_e?" do
+    assert Suffix.ends_e?("vote") == true
+    assert Suffix.ends_e?("stitch") == false
+    assert Suffix.ends_e?("inn") == false
+    assert Suffix.ends_e?("carry") == false
+    assert Suffix.ends_e?("run") == false
   end
 
   test "ends_ie?" do


### PR DESCRIPTION
The rules I imported from other modules weren't always correct, it seems